### PR TITLE
Support for RTP forwarding in WHIP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Considering Janus is used as a backend, before a WHIP endpoint can be negotiated
 	"room": <VideoRoom room ID to publish media to>,
 	"pin": <VideoRoom room pin, if required to join (optional)>,
 	"label": <Display name to use in the VideoRoom room (optional)>,
-	"token": "<token to require via Bearer authorization when using WHIP (optional)>
+	"token": "<token to require via Bearer authorization when using WHIP (optional)>,
+	"iceServers": [ array of STUN/TURN servers to return via Link headers (optional) ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ Considering Janus is used as a backend, before a WHIP endpoint can be negotiated
 	"pin": <VideoRoom room pin, if required to join (optional)>,
 	"label": <Display name to use in the VideoRoom room (optional)>,
 	"token": "<token to require via Bearer authorization when using WHIP (optional)>,
-	"iceServers": [ array of STUN/TURN servers to return via Link headers (optional) ]
+	"iceServers": [ array of STUN/TURN servers to return via Link headers (optional) ],
+	"recipient": { ... plain RTP recipient (optional) ... },
+	"secret": <VideoRoom secret, if required for external RTP forwarding (optional)>,
+	"adminKey": <VideoRoom plugin Admin Key, if required for external RTP forwarding (optional)>
 }
 ```
 

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,8 @@ module.exports = {
 	allowTrickle: true,
 
 	// In case we need to always return a set of STUN/TURN servers to
-	// WHIP clients via a Link header, we can put them here
+	// WHIP clients via a Link header (unless some servers have been provided
+	// as part of the endpoint creation request), we can put them here
 	iceServers: [
 		//~ { uri: 'stun:stun.example.net' },
 		//~ { uri: 'turn:turn.example.net?transport=udp', username: 'user', credential: 'password' },

--- a/src/server.js
+++ b/src/server.js
@@ -156,10 +156,13 @@ function setupRest(app) {
 		whip.debug("/create:", req.body);
 		var id = req.body.id;
 		var room = req.body.room;
+		var secret = req.body.secret;
+		var adminKey = req.body.adminKey;
 		var pin = req.body.pin;
 		var label = req.body.label;
 		var token = req.body.token;
 		var iceServers = req.body.iceServers;
+		var recipient = req.body.recipient;
 		if(!id || !room) {
 			res.status(400);
 			res.send('Invalid arguments');
@@ -173,10 +176,13 @@ function setupRest(app) {
 		endpoints[id] = {
 			id: id,
 			room: room,
+			secret: secret,
+			adminKey: adminKey,
 			pin: pin,
 			label: label ? label : "WHIP Publisher " + room,
 			token: token,
 			iceServers: iceServers,
+			recipient: recipient,
 			enabled: false
 		};
 		whip.info('[' + id + '] Created new WHIP endpoint');
@@ -310,6 +316,11 @@ function setupRest(app) {
 				sdp: req.body
 			}
 		};
+		if(endpoint.recipient) {
+			details.secret = endpoint.secret;
+			details.adminKey = endpoint.adminKey;
+			details.recipient = endpoint.recipient;
+		}
 		endpoint.enabled = true;
 		endpoint.publisher = uuid;
 		// Take note of SDP and ICE credentials

--- a/src/server.js
+++ b/src/server.js
@@ -159,6 +159,7 @@ function setupRest(app) {
 		var pin = req.body.pin;
 		var label = req.body.label;
 		var token = req.body.token;
+		var iceServers = req.body.iceServers;
 		if(!id || !room) {
 			res.status(400);
 			res.send('Invalid arguments');
@@ -175,6 +176,7 @@ function setupRest(app) {
 			pin: pin,
 			label: label ? label : "WHIP Publisher " + room,
 			token: token,
+			iceServers: iceServers,
 			enabled: false
 		};
 		whip.info('[' + id + '] Created new WHIP endpoint');
@@ -212,11 +214,12 @@ function setupRest(app) {
 			}
 		}
 		// Done
-		if(config.iceServers && config.iceServers.length > 0) {
+		var iceServers = endpoint.iceServers ? endpoint.iceServers : config.iceServers;
+		if(iceServers && iceServers.length > 0) {
 			// Add a Link header for each static ICE server
 			res.setHeader('Access-Control-Expose-Headers', 'Link');
 			var links = [];
-			for(var server of config.iceServers) {
+			for(var server of iceServers) {
 				if(!server.uri || (server.uri.indexOf('stun:') !== 0 &&
 						server.uri.indexOf('turn:') !== 0 &&
 						server.uri.indexOf('turns:') !== 0))
@@ -331,10 +334,11 @@ function setupRest(app) {
 				// Done
 				res.setHeader('Access-Control-Expose-Headers', 'Location, Link');
 				res.setHeader('Location', endpoint.resource);
-				if(config.iceServers && config.iceServers.length > 0) {
+				var iceServers = endpoint.iceServers ? endpoint.iceServers : config.iceServers;
+				if(iceServers && iceServers.length > 0) {
 					// Add a Link header for each static ICE server
 					var links = [];
-					for(var server of config.iceServers) {
+					for(var server of iceServers) {
 						if(!server.uri || (server.uri.indexOf('stun:') !== 0 &&
 								server.uri.indexOf('turn:') !== 0 &&
 								server.uri.indexOf('turns:') !== 0))

--- a/src/whip-janus.js
+++ b/src/whip-janus.js
@@ -286,10 +286,10 @@ var whipJanus = function(janusConfig) {
 							adminKey: adminKey,		// RTP forwarding may need the plugin Admin Key
 							recipient: recipient
 						};
-						that.forward(forwardDetails, function(err, result) {
+						that.forward(forwardDetails, function(err) {
 							if(err) {
 								// Something went wrong
-								that.hangup({uuid: uuid });
+								that.hangup({ uuid: uuid });
 								callback(err);
 								return;
 							}
@@ -331,7 +331,7 @@ var whipJanus = function(janusConfig) {
 		var max32 = Math.pow(2, 32) - 1
 		var forward = {
 			janus: "message",
-			session_id: that.config.janus.session,
+			session_id: that.config.janus.session.id,
 			handle_id: session.handle,
 			body: {
 				request: "rtp_forward",


### PR DESCRIPTION
While the WHIP server is only meant as a proof of concept to show how you can use WHIP as a frontend to Janus, I thought it may make sense to expand on it a bit. Specifically, the WHIP server currently only allows you to ingest a WebRTC stream in a VideoRoom room: this means the stream can, out of the box, only be consumed via that VideoRoom on the same Janus instance. As people familiar with Janus will know, RTP forwarding is an easy way to help implementing scalability of streams sent to a VideoRoom. This patch allows the WHIP server to automatically RTP forward a published stream to a provided external address: how this stream is then handled outside of Janus is out of scope.

To do so, you just add a `recipient` attribute when creating a WHIP endpoint, which needs to include `host`, `audioPort`, `videoPort` and/or `videoRtcpPort` of the recipient (e.g., a Streaming plugin mountpoint). Notice that, if the VideoRoom is configured to require a secret and/or admin key to do RTP forwarding, you'll need to pass `secret` and/or `adminKey` to the create request as well.