### PR TITLE
Added support for more Janus plugins for publishing, besides the VideoRoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,15 @@ The object to pass when creating a new endpoint must refer to the following stru
 ```
 {
 	id: "<unique ID of the endpoint to create>",
-	room: <VideoRoom room ID to publish media to>,
-	pin: <VideoRoom room pin, if required to join (optional)>,
-	label: <Display name to use in the VideoRoom room (optional)>,
-	token: "<token to require via Bearer authorization when using WHIP: can be either a string, or a callback function to validate the provided token (optional)>,
+	plugin: "<ID of the Janus plugin to publish to (optional, default=videoroom; supported=videoroom,audiobridge,recordplay,ndi)>",
+	room: <VideoRoom|AudioBridge room ID to publish media to (mandatory when using VideoRoom or AudioBridge)>,
+	pin: <VideoRoom|AudioBridge room pin, if required to join (optional)>,
+	label: "<Display name to use in the VideoRoom|AudioBridge room, Record&Play recording or as an NDI sender (optional)">,
+	token: "<token to require via Bearer authorization when using WHIP: can be either a string, or a callback function to validate the provided token (optional)>",
 	iceServers: [ array of STUN/TURN servers to return via Link headers (optional, overrides global ones) ],
-	recipient: { ... plain RTP recipient (optional) ... },
-	secret: <VideoRoom secret, if required for external RTP forwarding (optional)>,
-	adminKey: <VideoRoom plugin Admin Key, if required for external RTP forwarding (optional)>
+	recipient: { ... plain RTP recipient (optional, only supported for VideoRoom) ... },
+	secret: "<VideoRoom secret, if required for external RTP forwarding (optional)>",
+	adminKey: "<VideoRoom plugin Admin Key, if required for external RTP forwarding (optional)>"
 }
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,4 +7,10 @@ This folder contains a few example applications using the Janus WHIP library.
 
 * The `server-shared` folder, instead, contains an example where the application pre-creates a REST server for its own needs, and then tells the library to re-use that server for the WHIP functionality too. A sample endpoint is created, with a callback function used to validate the token any time one is presented.
 
-Both demos subscribe to a few of the events the library can emit for debugging purposes.
+* The `audiobridge` folder shows how you can configure a WHIP endpoint to publish to the AudioBridge plugin, instead of the VideoRoom (which is the default).
+
+* The `recordplay` folder shows how you can configure a WHIP endpoint to publish to the RecordPlay plugin, instead of the VideoRoom (which is the default), thus simply recording the published media to a Janus recording.
+
+* The `ndi` folder shows how you can configure a WHIP endpoint to publish to the [NDI plugin](https://github.com/meetecho/janus-ndi), instead of the VideoRoom (which is the default), in order to have the WebRTC stream turned into an NDI sender. Notice that this will fail if the NDI plugin is not available in the Janus instance.
+
+All demos subscribe to a few of the events the library can emit for debugging purposes.

--- a/examples/audiobridge/package.json
+++ b/examples/audiobridge/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "janus-whip-audiobridge",
+	"description": "WHIP server where the library publishes to the AudioBridge plugin",
+	"type": "module",
+	"keywords": [
+		"whip",
+		"wish",
+		"janus",
+		"audiobridge",
+		"webrtc",
+		"meetecho"
+	],
+	"author": {
+		"name": "Lorenzo Miniero",
+		"email": "lorenzo@meetecho.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/meetecho/simple-whip-server.git"
+	},
+	"license": "ISC",
+	"private": true,
+	"main": "src/index.js",
+	"dependencies": {},
+	"scripts": {
+		"build": "npm install --omit=dev",
+		"start": "node src/index.js"
+	}
+}

--- a/examples/audiobridge/src/index.js
+++ b/examples/audiobridge/src/index.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import http from 'http';
+import { JanusWhipServer } from '../../../src/whip.js';
+
+(async function main() {
+	console.log('Example: WHIP server publishing to the AudioBridge plugin');
+	let server = null;
+
+	// Create an HTTP server and bind to port 7180 just to list endpoints
+	let myApp = express();
+	myApp.get('/endpoints', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listEndpoints()));
+	});
+	http.createServer({}, myApp).listen(7180);
+
+	// Create a WHIP server, binding to port 7080 and using base path /whip
+	server = new JanusWhipServer({
+		janus: {
+			address: 'ws://localhost:8188'
+		},
+		rest: {
+			port: 7080,
+			basePath: '/whip'
+		}
+	});
+	// Add a couple of global event handlers
+	server.on('janus-disconnected', () => {
+		console.log('WHIP server lost connection to Janus');
+	});
+	server.on('janus-reconnected', () => {
+		console.log('WHIP server reconnected to Janus');
+	});
+	// Start the server
+	await server.start();
+
+	// Create a test endpoint using a static token, and referring to
+	// the AudioBridge plugin instead of the VideoRoom plugin: both
+	// plugins use mostly the same idenfitiers, so room works here too
+	let endpoint = server.createEndpoint({ id: 'abc123', plugin: 'audiobridge', room: 1234, token: 'verysecret' });
+	endpoint.on('endpoint-active', function() {
+		console.log(this.id + ': Endpoint is active');
+	});
+	endpoint.on('endpoint-inactive', function() {
+		console.log(this.id + ': Endpoint is inactive');
+	});
+}());

--- a/examples/ndi/package.json
+++ b/examples/ndi/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "janus-whip-ndi",
+	"description": "WHIP server where the library publishes to NDI",
+	"type": "module",
+	"keywords": [
+		"whip",
+		"wish",
+		"janus",
+		"webrtc",
+		"ndi",
+		"meetecho"
+	],
+	"author": {
+		"name": "Lorenzo Miniero",
+		"email": "lorenzo@meetecho.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/meetecho/simple-whip-server.git"
+	},
+	"license": "ISC",
+	"private": true,
+	"main": "src/index.js",
+	"dependencies": {},
+	"scripts": {
+		"build": "npm install --omit=dev",
+		"start": "node src/index.js"
+	}
+}

--- a/examples/ndi/src/index.js
+++ b/examples/ndi/src/index.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import http from 'http';
+import { JanusWhipServer } from '../../../src/whip.js';
+
+(async function main() {
+	console.log('Example: WHIP server publishing to the NDI plugin');
+	let server = null;
+
+	// Create an HTTP server and bind to port 7180 just to list endpoints
+	let myApp = express();
+	myApp.get('/endpoints', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listEndpoints()));
+	});
+	http.createServer({}, myApp).listen(7180);
+
+	// Create a WHIP server, binding to port 7080 and using base path /whip
+	server = new JanusWhipServer({
+		janus: {
+			address: 'ws://localhost:8188'
+		},
+		rest: {
+			port: 7080,
+			basePath: '/whip'
+		}
+	});
+	// Add a couple of global event handlers
+	server.on('janus-disconnected', () => {
+		console.log('WHIP server lost connection to Janus');
+	});
+	server.on('janus-reconnected', () => {
+		console.log('WHIP server reconnected to Janus');
+	});
+	// Start the server
+	await server.start();
+
+	// Create a test endpoint using a static token, and referring to
+	// the NDI plugin instead of the VideoRoom plugin: the NDI plugin
+	// ignores room, and uses a label instead (to use as sender name)
+	let endpoint = server.createEndpoint({ id: 'abc123', plugin: 'ndi', label: 'My WHIP Endpoint', token: 'verysecret' });
+	endpoint.on('endpoint-active', function() {
+		console.log(this.id + ': Endpoint is active');
+	});
+	endpoint.on('endpoint-inactive', function() {
+		console.log(this.id + ': Endpoint is inactive');
+	});
+}());

--- a/examples/recordplay/package.json
+++ b/examples/recordplay/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "janus-whip-recordplay",
+	"description": "WHIP server where the library publishes to the Record&Play plugin",
+	"type": "module",
+	"keywords": [
+		"whip",
+		"wish",
+		"janus",
+		"recordplay",
+		"webrtc",
+		"meetecho"
+	],
+	"author": {
+		"name": "Lorenzo Miniero",
+		"email": "lorenzo@meetecho.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/meetecho/simple-whip-server.git"
+	},
+	"license": "ISC",
+	"private": true,
+	"main": "src/index.js",
+	"dependencies": {},
+	"scripts": {
+		"build": "npm install --omit=dev",
+		"start": "node src/index.js"
+	}
+}

--- a/examples/recordplay/src/index.js
+++ b/examples/recordplay/src/index.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import http from 'http';
+import { JanusWhipServer } from '../../../src/whip.js';
+
+(async function main() {
+	console.log('Example: WHIP server publishing to the Record&Play plugin');
+	let server = null;
+
+	// Create an HTTP server and bind to port 7180 just to list endpoints
+	let myApp = express();
+	myApp.get('/endpoints', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listEndpoints()));
+	});
+	http.createServer({}, myApp).listen(7180);
+
+	// Create a WHIP server, binding to port 7080 and using base path /whip
+	server = new JanusWhipServer({
+		janus: {
+			address: 'ws://localhost:8188'
+		},
+		rest: {
+			port: 7080,
+			basePath: '/whip'
+		}
+	});
+	// Add a couple of global event handlers
+	server.on('janus-disconnected', () => {
+		console.log('WHIP server lost connection to Janus');
+	});
+	server.on('janus-reconnected', () => {
+		console.log('WHIP server reconnected to Janus');
+	});
+	// Start the server
+	await server.start();
+
+	// Create a test endpoint using a static token, and referring to
+	// the Record&Play plugin instead of the VideoRoom plugin: the
+	// Record&Play plugin doesn't use room, so we just set a label
+	let endpoint = server.createEndpoint({ id: 'abc123', plugin: 'recordplay', label: 'My WHIP Endpoint', token: 'verysecret' });
+	endpoint.on('endpoint-active', function() {
+		console.log(this.id + ': Endpoint is active');
+	});
+	endpoint.on('endpoint-inactive', function() {
+		console.log(this.id + ': Endpoint is inactive');
+	});
+}());

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 	"dependencies": {
 		"cors": "^2.8.5",
 		"express": "^5.1.0",
-		"janode": "^1.7.4"
+		"janode": "^1.8.0",
+		"janode-ndi": "^1.0.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.4.0",


### PR DESCRIPTION
This is an attempt to make the WHIP module more flexible. It currently only allows you to publish a WebRTC PeerConnection to the VideoRoom plugin, which makes sense since it's the SFU in Janus, but there are times where it may be helpful to also publish to a different plugin instead. As a proof-of-concept, this PR adds support for:

* AudioBridge (audio only)
* Record&Play (media is saved locally on the Janus instance, and goes nowhere else)
* [NDI plugin](https://github.com/meetecho/janus-ndi/) (to turn a WHIP stream into an NDI feed)

Considering there's flexibility in which plugins to use, now, the API is a bit rough, as everything is flattened in the same object, which is ugly to see and poor in terms of mantainability/extensibility. Before merging I'll probably change the way you create WHIP endpoints by having plugin-specific objects where you can specify the associated properties (e.g., the room to join for VideoRoom vs. the ID of the recording to save if using Record&Play, for instance).

Notice that, to support the Record&Play and NDI plugins. this bumps the Janode requirement to the new v1.8.0.